### PR TITLE
Fix compilation error on some systems

### DIFF
--- a/minIP.c
+++ b/minIP.c
@@ -13,7 +13,10 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#define __USE_MISC
+/* net/if.h requires flag __USE_MISC on some systems to set standard interface flags */
 #include <net/if.h>
+#undef __USE_MISC
 #include <net/ethernet.h>
 #include <sys/ioctl.h>
 #include <netpacket/packet.h>


### PR DESCRIPTION
Compilation was failing on some systems due to net/if.h not working correctly.
To fix this, the flag __USE_MISC needs to be set.
